### PR TITLE
Fix for tautological comparison in image_util.c 

### DIFF
--- a/image_util/image_util.c
+++ b/image_util/image_util.c
@@ -451,7 +451,7 @@ void transform_output_image(uint16_t *bmp, uint8_t *m, int count)
 
 void transform_output_image_adjustable(uint16_t *bmp, uint8_t *m, int src_w, int src_h, int dst_w, int dst_h)
 { /*{{{*/
-    if (src_w == dst_w && src_h == src_h)
+    if (src_w == dst_w && src_h == dst_h)
         transform_output_image(bmp, m, src_h*src_w);
     else
     {


### PR DESCRIPTION
On compilation, the following error is thrown:

```
../components/esp-face/image_util/image_util.c:454:33: error: 
     self-comparison always evaluates to true [-Werror=tautological-compare]

     if (src_w == dst_w && src_h == src_h)
                           ^^^^^^^^^^^^^^
```

The pull request fixes this by changing the the offending [line 454](https://github.com/espressif/esp-face/blob/41c628baf31a67c23f4e953ae2ead2da47aace5b/image_util/image_util.c#L454) to: 

```
     if (src_w == dst_w && src_h == dst_h)
```